### PR TITLE
Update ELM.java

### DIFF
--- a/classifiers/src/main/java/moa/classifiers/ann/ELM.java
+++ b/classifiers/src/main/java/moa/classifiers/ann/ELM.java
@@ -145,7 +145,13 @@ public class ELM extends AbstractClassifier implements MultiClassClassifier
                 input.set(startIndex + (int)instance.value(attrIndex), 1.0);
             }
         }
-        return Nd4j.create(input);
+        
+        float[][] data = new float[1][input.size()];
+        
+        for(int i = 0; i < input.size(); i++)
+        	data[0][i] = input.get(i).floatValue();
+        
+        return Nd4j.create(data);
     }
 
     public static INDArray getInstanceTarget(Instance instance)


### PR DESCRIPTION
Fixes matrix multiplication error in line 65 "return Transforms.sigmoid(getInstanceData(instance).mmul(alpha).add(bias)).mmul(beta).data().asDouble();"
Previous: getInstanceData(instance) returned 1D array size [N] incompatible with matrix multiplication [N,K]
Now: getInstanceData(instance) returns 2D array size [1,N] compatible with matrix multiplication [N,K]